### PR TITLE
Added ScrollToElement before Click, EnterText and Clear actions to fix #26

### DIFF
--- a/Xenon.Selenium/SeleniumXenonBrowser.cs
+++ b/Xenon.Selenium/SeleniumXenonBrowser.cs
@@ -28,7 +28,7 @@ namespace Xenon.Selenium
 
 		private IXenonElement ConvertToXenonElement( IWebElement webElement )
 		{
-			return new SeleniumXenonElement( webElement );
+			return new SeleniumXenonElement( _driver, webElement );
 		}
 
 		public IEnumerable<IXenonElement> FindElementsByCssSelector( string cssSelector )

--- a/Xenon.Selenium/SeleniumXenonElement.cs
+++ b/Xenon.Selenium/SeleniumXenonElement.cs
@@ -1,24 +1,29 @@
 using OpenQA.Selenium;
+using OpenQA.Selenium.Interactions;
 
 namespace Xenon.Selenium
 {
 	public class SeleniumXenonElement : IXenonElement
 	{
+		private readonly IWebDriver _webDriver;
 		private readonly IWebElement _webElement;
 
-		public SeleniumXenonElement( IWebElement webElement )
+		public SeleniumXenonElement( IWebDriver webDriver, IWebElement webElement )
 		{
+			_webDriver = webDriver;
 			_webElement = webElement;
 		}
 
-		public void Click()
+		public IXenonElement Click()
 		{
 			_webElement.Click();
+			return this;
 		}
 
-		public void EnterText( string value )
+		public IXenonElement EnterText( string value )
 		{
 			_webElement.SendKeys( value );
+			return this;
 		}
 
 		public bool IsVisible { get { return _webElement.Displayed; } }
@@ -28,9 +33,17 @@ namespace Xenon.Selenium
 	        get { return _webElement.Text; }
 	    }
 
-	    public void Clear()
+	    public IXenonElement Clear()
 	    {
 	        _webElement.Clear();
-	    }
+			return this;
+		}
+
+		public IXenonElement ScrollToElement()
+		{
+			var actions = new Actions( _webDriver );
+			actions.MoveToElement( _webElement ).Perform();
+			return this;
+		}
 	}
 }

--- a/Xenon/BaseXenonTest.cs
+++ b/Xenon/BaseXenonTest.cs
@@ -67,7 +67,7 @@ namespace Xenon
 		/// <param name="customPostWait">Custom action wait upon after clicking to the element</param>
 		public T Click( string cssSelector, AssertionFunc customPreWait = null, AssertionFunc customPostWait = null )
 		{
-			return RunTask( browser => browser.FindElementsByCssSelector( cssSelector ).First().Click(),
+			return RunTask( browser => browser.FindElementsByCssSelector( cssSelector ).First().ScrollToElement().Click(),
 				customPreWait ?? ( a => a.ContainsElement( cssSelector ) ),
 				customPostWait );
 		}
@@ -92,7 +92,7 @@ namespace Xenon
 			var foundElements = elements.Where( x => x.IsVisible ).ToList();
 
 			if ( foundElements.Count == 1 )
-				foundElements.First().Click();
+				foundElements.First().ScrollToElement().Click();
 			else if ( foundElements.Count > 1 )
 				throw new Exception( "More than one element was found" );
 			else
@@ -110,7 +110,7 @@ namespace Xenon
 		/// <param name="customPostWait">Custom action wait upon after entering the text in the element</param>
 		public T EnterText( string cssSelector, string text, AssertionFunc customPreWait = null, AssertionFunc customPostWait = null )
 		{
-			return RunTask( browser => browser.FindElementsByCssSelector( cssSelector ).First().EnterText( text ),
+			return RunTask( browser => browser.FindElementsByCssSelector( cssSelector ).First().ScrollToElement().EnterText( text ),
 				customPreWait ?? ( a => a.ContainsElement( cssSelector ) ),
 				customPostWait );
 		}
@@ -124,7 +124,7 @@ namespace Xenon
 		/// <param name="customPostWait">Custom action wait upon after entering the text in the element</param>
 		public T Clear( string cssSelector, AssertionFunc customPreWait = null, AssertionFunc customPostWait = null )
 		{
-			return RunTask( browser => browser.FindElementsByCssSelector( cssSelector ).First().Clear(),
+			return RunTask( browser => browser.FindElementsByCssSelector( cssSelector ).First().ScrollToElement().Clear(),
 				customPreWait ?? ( a => a.ContainsElement( cssSelector ) ),
 				customPostWait );
 		}

--- a/Xenon/IXenonElement.cs
+++ b/Xenon/IXenonElement.cs
@@ -2,10 +2,11 @@
 {
 	public interface IXenonElement
 	{
-		void Click();
-		void EnterText( string value );
+		IXenonElement Click();
+		IXenonElement EnterText( string value );
 		bool IsVisible { get; }
 	    string Text { get; }
-	    void Clear();
+		IXenonElement Clear();
+		IXenonElement ScrollToElement();
 	}
 }


### PR DESCRIPTION
Things which have been done in this pull request.

* Added ScrollToElement in IXenonElement and selenium implementation
* Changed IXenonElement methods to fluent methods
* Updated existing tests to make sure ScrollToElement is called before the actual action