### PR TITLE
Use Activator.CreateInstance for switching between screens

### DIFF
--- a/Xenon.Tests/DummyXenonScreen.cs
+++ b/Xenon.Tests/DummyXenonScreen.cs
@@ -2,7 +2,6 @@
 {
 	public class DummyXenonScreen : XenonScreen<DummyXenonScreen>
 	{
-		public DummyXenonScreen( IXenonBrowser xenonBrowser ) : base( xenonBrowser ) { }
-		public DummyXenonScreen( IXenonBrowser browser, XenonTestOptions options ) : base( browser, options ) { }
+		public DummyXenonScreen( IXenonBrowser browser, XenonTestOptions options = null) : base( browser, options ) { }
 	}
 }

--- a/Xenon.Tests/XenonScreenTests.cs
+++ b/Xenon.Tests/XenonScreenTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 
 namespace Xenon.Tests
@@ -15,11 +10,6 @@ namespace Xenon.Tests
 		{
 			private readonly IXenonBrowser _browser;
 			private readonly XenonTestOptions _options;
-
-			public DummyScreenHelper( IXenonBrowser browser ) : base( browser )
-			{
-				_browser = browser;
-			}
 
 			public DummyScreenHelper( IXenonBrowser browser, XenonTestOptions options ) : base( browser, options )
 			{
@@ -40,14 +30,12 @@ namespace Xenon.Tests
 
 		public class ScreenA : DummyScreenHelper<ScreenA>
 		{
-			public ScreenA( IXenonBrowser xenonBrowser ) : base( xenonBrowser ) {}
-			public ScreenA( IXenonBrowser browser, XenonTestOptions options ) : base( browser, options ) {}
+			public ScreenA( IXenonBrowser browser, XenonTestOptions options = null ) : base( browser, options ) {}
 		}
 
 		public class ScreenB : DummyScreenHelper<ScreenB>
 		{
-			public ScreenB( IXenonBrowser xenonBrowser ) : base( xenonBrowser ) {}
-			public ScreenB( IXenonBrowser browser, XenonTestOptions options ) : base( browser, options ) {}
+			public ScreenB( IXenonBrowser browser, XenonTestOptions options = null ) : base( browser, options ) {}
 		}
 
 		[Test]
@@ -66,13 +54,12 @@ namespace Xenon.Tests
 
 		public class FirstScreenWhenNextScreenHasOnly1Constructor : DummyScreenHelper<FirstScreenWhenNextScreenHasOnly1Constructor>
 		{
-			public FirstScreenWhenNextScreenHasOnly1Constructor( IXenonBrowser browser ) : base( browser ) {}
-			public FirstScreenWhenNextScreenHasOnly1Constructor( IXenonBrowser browser, XenonTestOptions options ) : base( browser, options ) {}
+			public FirstScreenWhenNextScreenHasOnly1Constructor( IXenonBrowser browser, XenonTestOptions options = null ) : base( browser, options ) {}
 		}
 
 		public class SecondScreenWhenNextScreenHasOnly1Constructor : DummyScreenHelper<SecondScreenWhenNextScreenHasOnly1Constructor>
 		{
-			public SecondScreenWhenNextScreenHasOnly1Constructor( IXenonBrowser browser ) : base( browser ) {}
+			public SecondScreenWhenNextScreenHasOnly1Constructor( IXenonBrowser browser, XenonTestOptions options = null ) : base( browser, options ) {}
 		}
 
 		[Test]

--- a/Xenon/BaseXenonTest.cs
+++ b/Xenon/BaseXenonTest.cs
@@ -9,11 +9,9 @@ namespace Xenon
 		protected readonly XenonTestOptions _xenonTestOptions;
 		protected IXenonBrowser _xenonBrowser;
 
-		protected BaseXenonTest( IXenonBrowser xenonBrowser ) : this( xenonBrowser, XenonTestOptions.Options ?? new XenonTestOptions() ) {}
-
-		protected BaseXenonTest( IXenonBrowser browser, XenonTestOptions options )
+		protected BaseXenonTest( IXenonBrowser browser, XenonTestOptions options = null )
 		{
-			_xenonTestOptions = options;
+			_xenonTestOptions = options ?? XenonTestOptions.Options ?? new XenonTestOptions();
 			_xenonBrowser = browser;
 		}
 

--- a/Xenon/XenonScreen.cs
+++ b/Xenon/XenonScreen.cs
@@ -1,42 +1,21 @@
 ﻿using System;
-using System.Linq;
-using System.Reflection;
 
 namespace Xenon
 {
 	public class XenonScreen<T> : BaseXenonTest<T> where T : XenonScreen<T>
 	{
-		public XenonScreen( IXenonBrowser xenonBrowser ) : base( xenonBrowser ) { }
 		public XenonScreen( IXenonBrowser browser, XenonTestOptions options ) : base( browser, options ) { }
-
-		private static ConstructorInfo ConstructorContainingIXenonBrowserAndXenonTestOptions<TNew>( ConstructorInfo[] constructors ) where TNew : XenonScreen<TNew>
-		{
-			return constructors.FirstOrDefault( x => x.GetParameters().Count() == 2 && x.GetParameters().First().ParameterType == typeof( IXenonBrowser ) && x.GetParameters().ElementAt( 1 ).ParameterType == typeof( XenonTestOptions ) );
-		}
-
-		private static ConstructorInfo ConstructorContainingIXenonBrowser<TNew>( ConstructorInfo[] constructors ) where TNew : XenonScreen<TNew>
-		{
-			return constructors.FirstOrDefault(x => x.GetParameters().Count() == 1 && x.GetParameters().First().ParameterType == typeof(IXenonBrowser)   );
-		}
-
-		private TNew CreateInstance<TNew>( ConstructorInfo constructor, params object[] parameters ) where TNew : XenonScreen<TNew>
-		{
-			return (TNew)constructor.Invoke( parameters );
-		}
 
 		public TNew Switch<TNew>() where TNew : XenonScreen<TNew>
 		{
-			var constructors = typeof( TNew ).GetConstructors();
-
-			var constructorWith2Params = ConstructorContainingIXenonBrowserAndXenonTestOptions<TNew>( constructors );
-			if ( constructorWith2Params != null )
-				return CreateInstance<TNew>( constructorWith2Params, _xenonBrowser, _xenonTestOptions);
-
-			var constructorWith1Param = ConstructorContainingIXenonBrowser<TNew>( constructors );
-			if ( constructorWith1Param != null )
-				return CreateInstance<TNew>( constructorWith1Param, _xenonBrowser );
-
-			throw new Exception("Cannot find a constructor with parameter of type (IXenonBrowser) or (IXenonBrowser, XenonTestOptions) ");
+			try
+			{
+				return (TNew)Activator.CreateInstance( typeof( TNew ), _xenonBrowser, _xenonTestOptions );
+			}
+			catch
+			{
+				throw new Exception( $"Cannot find a constructor with parameter of type ({nameof(IXenonBrowser)}) or ({nameof(IXenonBrowser)}, {nameof(XenonTestOptions)}) " );
+			}
 		}
 	}
 }


### PR DESCRIPTION
Noticed this when digging around in Xenon -> lots of (unnecessary) `Reflection` code in Xenon screen and also the requirement to have two `ctor`s in every screen you create. PR is essentially just deletions 😄 