### PR TITLE
Make XenonElementsSearchResult transparent

### DIFF
--- a/Xenon.Tests/InputTests/XenonTestInputTests.cs
+++ b/Xenon.Tests/InputTests/XenonTestInputTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Linq;
 using NUnit.Framework;
 using Xenon.Tests.Integration;
 
@@ -35,7 +31,7 @@ namespace Xenon.Tests.InputTests
 		private static XenonAssertion InputHasExpectedValue( string inputType, string expectedValue, XenonAssertion xenonAssertion )
 		{
 			return xenonAssertion.CustomAssertion( y => y.FindElementsByCssSelector( $"input[type='{inputType}']" )
-				                               .Elements.First().Text == expectedValue );
+				                               .First().Text == expectedValue );
 		}
 	}
 }

--- a/Xenon/BaseXenonTest.cs
+++ b/Xenon/BaseXenonTest.cs
@@ -173,7 +173,7 @@ namespace Xenon
 		/// <returns></returns>
 		public T SelectList( string cssSelector, string text, AssertionFunc customPreWait = null, AssertionFunc customPostWait = null )
 		{
-			return RunTask( browser => browser.FindElementsByCssSelector( cssSelector ).Elements.First().SelectDropdownItem( text ),
+			return RunTask( browser => browser.FindElementsByCssSelector( cssSelector ).First().SelectDropdownItem( text ),
 				customPreWait ?? ( a => SelectListPreWait( a, cssSelector, text ) ),
 				customPostWait );
 		}
@@ -185,7 +185,7 @@ namespace Xenon
 				Click( cssSelector );
 
 				xenonAssertion.CustomAssertion(
-					browser => browser.FindElementsByCssSelector( cssSelector + " option" ).Elements.Any( x => x.Text == text ) );
+					browser => browser.FindElementsByCssSelector( cssSelector + " option" ).Any( x => x.Text == text ) );
 			}
 			return xenonAssertion;
 		}

--- a/Xenon/XenonAssertion.cs
+++ b/Xenon/XenonAssertion.cs
@@ -29,7 +29,7 @@ namespace Xenon
 		{
 		    var pageContains = _xenonBrowser.PageSource.Contains( content );
 		    if ( !pageContains )
-		        pageContains = _xenonBrowser.FindElementsByCssSelector( "input, textarea" ).Elements.Any( e => e.Text.Contains( content ) );
+		        pageContains = _xenonBrowser.FindElementsByCssSelector( "input, textarea" ).Any( e => e.Text.Contains( content ) );
 
             return Assert( pageContains, "Page does not contain: " + content );
 		}
@@ -41,7 +41,7 @@ namespace Xenon
 
 		public XenonAssertion ContainsElement( string cssSelector )
 		{
-			return Assert( _xenonBrowser.FindElementsByCssSelector( cssSelector ).Elements.Any( e => e.IsVisible ), "Page does not contain element with selector: " + cssSelector );
+			return Assert( _xenonBrowser.FindElementsByCssSelector( cssSelector ).Any( e => e.IsVisible ), "Page does not contain element with selector: " + cssSelector );
 		}
 
 		public XenonAssertion ContainsElement( Func<XenonElementsFinder, XenonElementsFinder> where )
@@ -52,7 +52,7 @@ namespace Xenon
 		public XenonAssertion DoesNotContainElement( string cssSelector )
 		{
 			var searchResult = _xenonBrowser.FindElementsByCssSelector( cssSelector );
-			return Assert( !searchResult.Elements.Any( e => e.IsVisible ), "Page contains element with selector: " + cssSelector );
+			return Assert( !searchResult.Any( e => e.IsVisible ), "Page contains element with selector: " + cssSelector );
 		}
 
 		public XenonAssertion DoesNotContainElement( Func<XenonElementsFinder, XenonElementsFinder> where )
@@ -63,7 +63,7 @@ namespace Xenon
 		private XenonAssertion BrowserContainsElement( Func<XenonElementsFinder, XenonElementsFinder> where, bool shouldContainElement )
 		{
 			var searchResult = where( new XenonElementsFinder( _xenonBrowser ) ).FindElements();
-			var elementsArePresentAndVisible = searchResult.Elements.Any( e => e.IsVisible );
+			var elementsArePresentAndVisible = searchResult.Any( e => e.IsVisible );
 			return Assert(
 				elementsArePresentAndVisible == shouldContainElement,
 				$"Page contains elements matching the following criteria: {searchResult}" );

--- a/Xenon/XenonElementsFinder.cs
+++ b/Xenon/XenonElementsFinder.cs
@@ -183,8 +183,8 @@ namespace Xenon
 		internal XenonElementsSearchResult FindElements()
 		{	
 			var criteria = _criteriaBuilder.GenerateCriteria();
-			var elements = _browser.FindElementsByXPath( criteria ).Elements;
-			return new XenonElementsSearchResult( elements, _criteriaBuilder.SearchCriteria );
+			var elements = _browser.FindElementsByXPath( criteria );
+			return new XenonElementsSearchResult( elements, _criteriaBuilder.SearchCriteria.ToArray() );
 		}
 
 		public string CriteriaDetails() => _criteriaBuilder.CriteriaDetails();

--- a/Xenon/XenonElementsSearchResult.cs
+++ b/Xenon/XenonElementsSearchResult.cs
@@ -4,37 +4,27 @@ using System.Linq;
 
 namespace Xenon
 {
-	public class XenonElementsSearchResult
+	public class XenonElementsSearchResult : List<IXenonElement>
 	{
 		private readonly string _searchCriteria;
-		public List<IXenonElement> Elements { get; }
 
-		internal XenonElementsSearchResult( List<IXenonElement> elements, IEnumerable<string> searchCriteria )
+		internal XenonElementsSearchResult( IEnumerable<IXenonElement> elements, params string[] searchCriteria )
+			: base( elements )
 		{
-			_searchCriteria = string.Join( ", ", searchCriteria );
-			Elements = elements;
-		}
-
-		internal XenonElementsSearchResult( List<IXenonElement> elements, string searchCriteria, params string[] additionalSearchCriteria )
-		{
-			_searchCriteria = string.Join( ", ", new List<string>( additionalSearchCriteria )
-			{
-				searchCriteria
-			} );
-			Elements = elements;
+			_searchCriteria = string.Join( ", ", new List<string>( searchCriteria ) );
 		}
 
 		internal IXenonElement LocateFirstVisibleElement()
 		{
 			ValidateResults();
-			return Elements.First( x => x.IsVisible ).ScrollToElement();
+			return this.First( x => x.IsVisible ).ScrollToElement();
 		}
 
 		internal IXenonElement LocateSingleVisibleElement()
 		{
 			ValidateResults();
 
-			var foundElements = Elements
+			var foundElements = this
 				.Where( x => x.IsVisible )
 				.ToList();
 
@@ -49,7 +39,7 @@ namespace Xenon
 
 		private void ValidateResults()
 		{
-			if ( !Elements.Any() )
+			if ( !this.Any() )
 				throw new NoElementsFoundException( _searchCriteria );
 		}
 


### PR DESCRIPTION
Had made a change in Xenon which had then caused Spawtz not to build because the API had changed, instead now `XenonElementsSearchResult` inherits from `List<IXenonElement>` so that the internals still work the same but from the outside the use is the same too