### PR TITLE
Fix modal bug

### DIFF
--- a/Xenon.Selenium.nuspec
+++ b/Xenon.Selenium.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd" >
 	<metadata>
 		<id>Xenon.Selenium</id>
-		<version>0.6.0</version>
+		<version>0.7.0</version>
 		<title>Xenon.Selenium</title>
 		<authors>Liquid Thinking</authors>
 		<projectUrl>https://github.com/LiquidThinking/Xenon</projectUrl>
@@ -13,7 +13,7 @@
 
 			This is browser automation wrapper for Selenium.
 		</description>
-		<releaseNotes>Added implementation of MoveToElement method</releaseNotes>
+		<releaseNotes>Allow client to selectively run Validation (fixes modal error)</releaseNotes>
 		<dependencies>
 			<dependency id="Selenium.Support" version="3.141.0.0" />
 			<dependency id="Selenium.WebDriver" version="3.141.0.0" />

--- a/Xenon.Tests/PageValidationTests/BasePageValidationFuncTests.cs
+++ b/Xenon.Tests/PageValidationTests/BasePageValidationFuncTests.cs
@@ -14,7 +14,7 @@ namespace Xenon.Tests.PageValidationTests
 				AssertMethod = Assert.IsTrue,
 				Validation = new Validation
 				{
-					NavAction = NavAction.GoToUrl | NavAction.Click,
+					UiAction = UiAction.GoToUrl | UiAction.Click,
 					Func = page =>
 						page.Source.Contains( "<h1>Error</h1>" )
 							? ErrorMessage
@@ -130,7 +130,7 @@ namespace Xenon.Tests.PageValidationTests
 		}
 
 		[Test]
-		public void ActionTriggeringModal_WhenActionExcludedFromValidation_CanHandleModal()
+		public void ActionTriggeringModal_WhenActionAndAssertionExcludedFromValidation_CanHandleModal()
 		{
 			using ( var browserTest = new BrowserTest(
 				XenonTestsResourceLookup
@@ -143,7 +143,9 @@ namespace Xenon.Tests.PageValidationTests
 						.FindElementsByCssSelector( "a" )
 						.Single()
 						.Click() )
-					.ClickDialogBox();
+					.ClickDialogBox()
+					.Assert( assertion => assertion
+						.PageContains( "Error" ) );
 			}
 		}
 	}

--- a/Xenon.Tests/PageValidationTests/BasePageValidationFuncTests.cs
+++ b/Xenon.Tests/PageValidationTests/BasePageValidationFuncTests.cs
@@ -128,5 +128,23 @@ namespace Xenon.Tests.PageValidationTests
 						} );
 			}
 		}
+
+		[Test]
+		public void ActionTriggeringModal_WhenActionExcludedFromValidation_CanHandleModal()
+		{
+			using ( var browserTest = new BrowserTest(
+				XenonTestsResourceLookup
+					.GetContent(
+						htmlFileName: "PageWithoutErrorHeader" ) ) )
+			{
+				CreateInstance( browserTest.Start() )
+					.GoToUrl( "/" )
+					.Custom( browser => browser
+						.FindElementsByCssSelector( "a" )
+						.Single()
+						.Click() )
+					.ClickDialogBox();
+			}
+		}
 	}
 }

--- a/Xenon.Tests/PageValidationTests/PageWithoutErrorHeader.html
+++ b/Xenon.Tests/PageValidationTests/PageWithoutErrorHeader.html
@@ -6,14 +6,23 @@
     <title>200</title>
     <script>
         window.onload = function() {
-            document.querySelector('button').addEventListener('click', function() {
-                document.querySelector('h1').textContent = 'Error';
-            });
+            document.querySelector('button').addEventListener('click',
+                function() {
+                    document.querySelector('h1').textContent = 'Error';
+                });
+
+            document.querySelector('a').addEventListener('click',
+                function() {
+                    if (confirm('Are you a fish?')) {
+                        document.querySelector('h1').textContent = 'Error';
+                    }
+                });
         }
     </script>
 </head>
 <body>
 <h1>200</h1>
 <button>Make Error</button>
+<a>Trigger Dialog, then Error</a>
 </body>
 </html>

--- a/Xenon.nuspec
+++ b/Xenon.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd" >
 	<metadata>
 		<id>Xenon</id>
-		<version>0.6.0</version>
+		<version>0.7.0</version>
 		<title>Xenon</title>
 		<authors>Liquid Thinking</authors>
 		<projectUrl>https://github.com/LiquidThinking/Xenon</projectUrl>
@@ -14,7 +14,7 @@
 			There are the following pre-built browser automation wrappers:
 			http://www.nuget.org/packages/Xenon.Selenium/
 		</description>
-		<releaseNotes>Add PageValidationFunc and date format to options</releaseNotes>
+		<releaseNotes>Allow client to selectively run Validation (fixes modal error)</releaseNotes>
 		<dependencies>
 		</dependencies>
 	</metadata>

--- a/Xenon/BaseXenonTest.cs
+++ b/Xenon/BaseXenonTest.cs
@@ -34,7 +34,7 @@ namespace Xenon
 			} while ( DateTime.Now < endTime );
 		}
 
-		private T RunTask( Action<IXenonBrowser> task, AssertionFunc preWait, AssertionFunc postWait, NavAction @action = NavAction.None  )
+		private T RunTask( Action<IXenonBrowser> task, AssertionFunc preWait, AssertionFunc postWait, NavAction @action = NavAction.None )
 		{
 			if ( preWait != null )
 				WaitUntil( preWait );
@@ -44,7 +44,8 @@ namespace Xenon
 				task( _xenonBrowser );
 
 				var validationAction = _xenonTestOptions.Validation?.NavAction;
-				if ( validationAction?.HasFlag( action ) ?? false )
+				if ( @action != NavAction.None 
+				     && ( validationAction?.HasFlag( action ) ?? false ) )
 				{
 					var error = CheckPage( _xenonBrowser );
 					if ( !string.IsNullOrEmpty( error ) )

--- a/Xenon/XenonTestOptions.cs
+++ b/Xenon/XenonTestOptions.cs
@@ -12,7 +12,7 @@ namespace Xenon
 		/// Optional hook to validate pages _generally_ after explicit navigation & in assertions
 		/// I.e. Check for default web server error text, or a malformed Url
 		/// </summary>
-		public Func<Page, string> PageValidationFunc { get; set; }
+		public Validation Validation { get; set; }
 
 		/// <summary>
 		/// The format to use for <see cref="DateTime"/>, defaults to <see cref="DefaultDateFormat"/>
@@ -51,13 +51,40 @@ namespace Xenon
 			{
 				WaitForSeconds = WaitForSeconds,
 				AssertMethod = AssertMethod,
-				PageValidationFunc = PageValidationFunc,
+				Validation = Validation,
 				DateFormat = DateFormat
 			};
 
 			mutate( @new );
 			return @new;
 		}
+	}
+
+	public class Validation
+	{
+		public NavAction NavAction { get; set; }
+		public Func<Page, string> Func { get; set; }
+
+		public Validation Clone( Action<Validation> mutate )
+		{
+			var @new = new Validation
+			{
+				Func = Func,
+				NavAction = NavAction
+			};
+
+			mutate( @new );
+			return @new;
+		}
+	}
+
+	[Flags]
+	public enum NavAction
+	{
+		None = 0,
+		GoToUrl = 1,
+		Click = 2,
+		Custom = 4
 	}
 
 	public class Page

--- a/Xenon/XenonTestOptions.cs
+++ b/Xenon/XenonTestOptions.cs
@@ -62,7 +62,7 @@ namespace Xenon
 
 	public class Validation
 	{
-		public NavAction NavAction { get; set; }
+		public UiAction UiAction { get; set; }
 		public Func<Page, string> Func { get; set; }
 
 		public Validation Clone( Action<Validation> mutate )
@@ -70,7 +70,7 @@ namespace Xenon
 			var @new = new Validation
 			{
 				Func = Func,
-				NavAction = NavAction
+				UiAction = UiAction
 			};
 
 			mutate( @new );
@@ -79,12 +79,13 @@ namespace Xenon
 	}
 
 	[Flags]
-	public enum NavAction
+	public enum UiAction
 	{
 		None = 0,
 		GoToUrl = 1,
 		Click = 2,
-		Custom = 4
+		Custom = 4,
+		Assertion = 8
 	}
 
 	public class Page


### PR DESCRIPTION
The Validation Func I added has broken the Modal stuff. I think there's limited time to dismiss/accept a modal, and this validation being run between actions has exceeded whatever it was happy with, or else running other actions on the driver without addressing the modal does it, I dunno. But the bahviour is clear - if you set a func to run on an action which triggers a modal, it does not work anymore, if you don't it does.

Refactored to pass a flags enum of actions you want to run validation on so that in tests where you trigger modals you can omit the checking on those actions